### PR TITLE
Fix version detection regex to find numbers 0-9 and update tests.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -50,7 +50,7 @@ install_play()
   echo "-----> done"
 }
 
-PLAY_VERSION=`grep 'play[ \t]*[0-9\.]' conf/dependencies.yml | sed -E -e 's/[ \t]*-[ \t]*play[ \t]*([1-9\.]*).*/\1/'`
+PLAY_VERSION=`grep 'play[ \t]*[0-9\.]' conf/dependencies.yml | sed -E -e 's/[ \t]*-[ \t]*play[ \t]*([0-9\.]*).*/\1/'`
 DEFAULT_PLAY_VERSION="1.2.4"
 VERSION_DECLARED=true
 

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -34,7 +34,7 @@ getPlayApp() {
   local playVersion=${1:-${DEFAULT_PLAY_VERSION}}
   local appBaseDir="${PLAY_TEST_CACHE}/app-${playVersion}"
   if [ ! -f ${appBaseDir}/conf/application.conf ]; then
-    $(_full_play) new ${appBaseDir} --name app
+    $(_full_play) new ${appBaseDir} --name app >/dev/null
   fi
   cp -r ${appBaseDir}/. ${BUILD_DIR}
   assertTrue "${BUILD_DIR}/conf/application.conf should be present after creating a new app." "[ -f ${BUILD_DIR}/conf/application.conf ]"
@@ -136,6 +136,7 @@ testPlayVersionIsPickedUpFromDependenciesFile() {
 
   compile
 
+  assertCaptured "Installing Play! 1.2.4"
   assertNotCaptured "WARNING: Play! version not specified in dependencies.yml."
 }
 
@@ -151,9 +152,12 @@ testPlayCopiedToCacheDirForSuccessfulBuild() {
 }
 
 testValidVersionOfPlayThatIsNotInS3Bucket() {
-  getPlayApp "1.1.1"
-  definePlayAppVersion "1.1.1"
+  getPlayApp "1.0.1"
+  definePlayAppVersion "1.0.1"
+  
   compile
+
+  assertCaptured "Installing Play! 1.0.1"
   assertCaptured "Error installing Play! framework or unsupported Play! framework version specified."
 }
 


### PR DESCRIPTION
This fixes the regex in the sed command to use version numbers 0-9. Updated the tests to have a version with a 0 in it (and made sure it failed before fixing it). Also, surpress play! output in test setup.

I did not extract the regex in play! like I did in grails because we only use it once, but if we start reading multiple yaml files, it would probably make sense. let me know if you think it needs it now.
