### PR TITLE
Do not detect Play 2.0 apps as Play 1.2.x 

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 # bin/use <build-dir>
 
-play_confs=`cd $1; find . -wholename "*/conf/application.conf" ! -wholename "*modules*" -type f`
-if [ -n "$play_confs" ]; then
+BUILD_DIR=$1
+
+play_confs=$(cd $BUILD_DIR; find . -wholename "*/conf/application.conf" ! -wholename "*modules*" -type f)
+
+if [ -n "$play_confs" ] && [ ! -f "$BUILD_DIR/project/Build.scala" ]; then
   echo "Play!" && exit 0
 else
   echo "no" && exit 1

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -31,3 +31,16 @@ testConfFileWithModulesDirectoryDoesNotDetectPlayApp() {
 
   assertNoAppDetected
 }
+
+testPlay20NotDetected()
+{
+  mkdir ${BUILD_DIR}/project
+  touch ${BUILD_DIR}/project/Build.scala
+  mkdir ${BUILD_DIR}/conf
+  touch ${BUILD_DIR}/conf/application.conf
+
+  detect
+
+  assertNoAppDetected
+}
+


### PR DESCRIPTION
This stops Play 2.0 apps from being detected as Play 1.2.x apps by checking for the non-existence of `project/Build.scala` per Issue #17. 

I looked at the [Play Scala module](http://www.playframework.org/modules/scala-0.9.1/home) for Play 1.2.x, and it does not look like this will conflict with that because it does not use SBT, but wanted to get some more eyes to see if there's any other reason someone might have a `project/Build.scala` file in a Play 1.2.x project. @sclasen, thoughts?

I also looked into using `conf/dependencies.yml`, but this is not strictly required in Play 1.2.x projects.
