### PR TITLE
Add a note about Play 2.0 being handled by another build pack in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Heroku buildpack: Play!
 
 This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpack) for [Play! framework](http://www.playframework.org/) apps.
 
+*Note: Play 2.0 apps are detected by the Scala build pack!*
+
 Usage
 -----
 


### PR DESCRIPTION
When explicitly using the play build pack for Play 2.0 apps, this doesn't work. It might take a while to realize you have to use the Scala build pack instead.
