### PR TITLE
Allow use of custom conf/ivysettings.xml file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -48,11 +48,20 @@ fi
 
 PLAY_SETTINGS_URL="http://s3.amazonaws.com/heroku-jvm-langpack-play/ivysettings.xml"
 
-echo -n "-----> Installing ivysettings.xml....."
+echo "-----> Installing ivysettings.xml....."
 if [ -f .ivy2/ivysettings.xml ]; then
+  echo -n "  ---> Removing old ivysettings.xml..."
   rm .ivy2/ivysettings.xml 
+  echo "done"
 fi
-curl --silent --max-time 10 --location $PLAY_SETTINGS_URL --create-dirs --output .ivy2/ivysettings.xml
+if [ -f conf/ivysettings.xml ]; then
+  echo -n "  ---> Installing custom ivysettings.xml..."
+  [ -d .ivy2 ] || mkdir .ivy2
+  cp conf/ivysettings.xml .ivy2/ivysettings.xml
+else
+  echo -n "  ---> Installing Heroku default ivysettings.xml..."
+  curl --silent --max-time 10 --location $PLAY_SETTINGS_URL --create-dirs --output .ivy2/ivysettings.xml
+fi
 echo " done"
 
 # Build app

--- a/bin/compile
+++ b/bin/compile
@@ -72,7 +72,7 @@ $PLAY_PATH/play version | sed -u 's/^/       /'
 APP_DIR=./
 echo "       Building Play! application at directory $APP_DIR"
 
-DEPENDENCIES_CMD="$PLAY_PATH/play dependencies $APP_DIR --forProd --forceCopy --silent --clearcache -Duser.home=$BUILD_DIR 2>&1"
+DEPENDENCIES_CMD="$PLAY_PATH/play dependencies $APP_DIR --forProd --forceCopy --silent -Duser.home=$BUILD_DIR 2>&1"
 echo "       Resolving dependencies: $DEPENDENCIES_CMD"
 eval "$DEPENDENCIES_CMD" | sed -u 's/^/       /'
 check_compile_status

--- a/bin/compile
+++ b/bin/compile
@@ -72,7 +72,7 @@ $PLAY_PATH/play version | sed -u 's/^/       /'
 APP_DIR=./
 echo "       Building Play! application at directory $APP_DIR"
 
-DEPENDENCIES_CMD="$PLAY_PATH/play dependencies $APP_DIR --forProd --forceCopy --silent -Duser.home=$BUILD_DIR 2>&1"
+DEPENDENCIES_CMD="$PLAY_PATH/play dependencies $APP_DIR --forProd --forceCopy --silent --clearcache -Duser.home=$BUILD_DIR 2>&1"
 echo "       Resolving dependencies: $DEPENDENCIES_CMD"
 eval "$DEPENDENCIES_CMD" | sed -u 's/^/       /'
 check_compile_status


### PR DESCRIPTION
Added logic that searches for conf/ivysettings.xml in the repo, and if present installs it as the ivysettings.xml for the Play application. If the file is not present, proceeds with the Heroku-provided ivysettings.xml file.