### PR TITLE
Call export_env_dir

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# bin/compile <build-dir> <cache-dir>
+# bin/compile <build-dir> <cache-dir> <env-dir>
 
 # Parse args
 BUILD_DIR=$1
 CACHE_DIR=$2
+ENV_DIR=$3
 
 BIN_DIR=$(cd $(dirname $0); pwd) # absolute path
 
@@ -11,7 +12,10 @@ BIN_DIR=$(cd $(dirname $0); pwd) # absolute path
 . $BIN_DIR/common.sh
 
 curl --silent --location http://heroku-jvm-common.s3.amazonaws.com/jvm-buildpack-common.tar.gz | tar xz
+. bin/util
 . bin/java
+
+export_env_dir $ENV_DIR
 
 #create the cache dir if it doesn't exist
 mkdir -p $CACHE_DIR


### PR DESCRIPTION
Add support for ENV_DIR. 

Tested with https://github.com/heroku/heroku-buildpack-play/compare/dep-opts, but not pull in at this point.

cc: @naaman 
